### PR TITLE
Feat : 실시간 알림 + 알림 기록 저장 기능

### DIFF
--- a/src/main/java/com/spacestar/back/alarm/controller/AlarmController.java
+++ b/src/main/java/com/spacestar/back/alarm/controller/AlarmController.java
@@ -22,6 +22,7 @@ import com.spacestar.back.global.ResponseEntity;
 import com.spacestar.back.global.ResponseSuccess;
 import com.spacestar.back.kafka.message.FriendMessage;
 import com.spacestar.back.kafka.message.MatchingMessage;
+import com.spacestar.back.kafka.message.Message;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,8 +41,6 @@ public class AlarmController {
 
 	private final AlarmServiceImpl alarmService;
 	private final ModelMapper modelMapper;
-	private final Sinks.Many<MatchingMessage> matchingSink;
-	private final Sinks.Many<FriendMessage> friendSink;
 
 	@PostMapping
 	@Operation(summary = "알림 생성")
@@ -63,13 +62,9 @@ public class AlarmController {
 	// 매칭 알림 실시간 수신
 	@GetMapping(value ="/stream-sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	@Operation(summary = "실시간 알림 SSE 입장")
-	public Flux<Object> matchingEvents(@RequestHeader("UUID") String uuid){
-		log.info("Received UUID: {}", uuid);
+	public Flux<Message> matchingEvents(@RequestHeader("UUID") String uuid){
 
-		return Flux.merge(
-				matchingSink.asFlux().filter(message -> uuid.equals(message.getReceiverUuid())),
-				friendSink.asFlux().filter(message -> uuid.equals(message.getReceiverUuid()))
-		);
+		return alarmService.streamAlarms(uuid);
 	}
 
 	@GetMapping("/state/{alarmId}")

--- a/src/main/java/com/spacestar/back/alarm/controller/AlarmController.java
+++ b/src/main/java/com/spacestar/back/alarm/controller/AlarmController.java
@@ -20,17 +20,14 @@ import com.spacestar.back.alarm.vo.res.AlarmListResVo;
 import com.spacestar.back.alarm.vo.res.AlarmStateResVo;
 import com.spacestar.back.global.ResponseEntity;
 import com.spacestar.back.global.ResponseSuccess;
-import com.spacestar.back.kafka.message.FriendMessage;
-import com.spacestar.back.kafka.message.MatchingMessage;
 import com.spacestar.back.kafka.message.Message;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.ws.rs.DELETE;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Sinks;
+import reactor.core.publisher.Mono;
 
 @Slf4j
 @RestController
@@ -45,7 +42,7 @@ public class AlarmController {
 	@PostMapping
 	@Operation(summary = "알림 생성")
 	public ResponseEntity<Void> addAlarm(@RequestHeader("UUID") String uuid,
-			@RequestBody AlarmAddReqVo alarmAddReqVo) {
+		@RequestBody AlarmAddReqVo alarmAddReqVo) {
 		alarmService.addAlarm(uuid, modelMapper.map(alarmAddReqVo, AlarmAddReqDto.class));
 		return new ResponseEntity<>(ResponseSuccess.ALARM_INSERT_SUCCESS);
 	}
@@ -56,13 +53,13 @@ public class AlarmController {
 	public ResponseEntity<AlarmListResVo> getAlarmList(@RequestHeader("UUID") String uuid) {
 
 		return new ResponseEntity<>(ResponseSuccess.ALARM_LIST_SELECT_SUCCESS,
-				modelMapper.map(alarmService.getAlarmList(uuid), AlarmListResVo.class));
+			modelMapper.map(alarmService.getAlarmList(uuid), AlarmListResVo.class));
 	}
 
 	// 매칭 알림 실시간 수신
-	@GetMapping(value ="/stream-sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	@GetMapping(value = "/stream-sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	@Operation(summary = "실시간 알림 SSE 입장")
-	public Flux<Message> matchingEvents(@RequestHeader("UUID") String uuid){
+	public Flux<Message> matchingEvents(@RequestHeader("UUID") String uuid) {
 
 		return alarmService.streamAlarms(uuid);
 	}
@@ -70,15 +67,15 @@ public class AlarmController {
 	@GetMapping("/state/{alarmId}")
 	@Operation(summary = "알림 상태 조회")
 	public ResponseEntity<AlarmStateResVo> getAlarmState(@RequestHeader("UUID") String uuid,
-			@PathVariable("alarmId") String alarmId) {
+		@PathVariable("alarmId") String alarmId) {
 		return new ResponseEntity<>(ResponseSuccess.ALARM_STATE_SELECT_SUCCESS,
-				modelMapper.map(alarmService.getAlarmState(uuid, alarmId), AlarmStateResVo.class));
+			modelMapper.map(alarmService.getAlarmState(uuid, alarmId), AlarmStateResVo.class));
 	}
 
 	@PatchMapping("/modify/check-status/{alarmId}")
 	@Operation(summary = "알림 상태 수정 (읽음으로 처리)")
 	public ResponseEntity<Void> modifyAlarmCheckStatus(@RequestHeader("UUID") String uuid,
-			@PathVariable("alarmId") String alarmId) {
+		@PathVariable("alarmId") String alarmId) {
 
 		alarmService.modifyAlarmRead(alarmId, uuid);
 		return new ResponseEntity<>(ResponseSuccess.ALARM_CHECK_STATE_UPDATE_SUCCESS);
@@ -87,7 +84,7 @@ public class AlarmController {
 	@DeleteMapping("/delete")
 	@Operation(summary = "알림 삭제")
 	public ResponseEntity<Void> deleteAlarm(@RequestHeader("UUID") String uuid,
-		@RequestBody AlarmDeleteReqDto alarmDeleteReqDto){
+		@RequestBody AlarmDeleteReqDto alarmDeleteReqDto) {
 		alarmService.deleteAlarm(uuid, alarmDeleteReqDto);
 		return new ResponseEntity<>(ResponseSuccess.ALARM_LIST_DELETE_SUCCESS);
 	}

--- a/src/main/java/com/spacestar/back/alarm/dto/req/AlarmAddReqDto.java
+++ b/src/main/java/com/spacestar/back/alarm/dto/req/AlarmAddReqDto.java
@@ -3,11 +3,14 @@ package com.spacestar.back.alarm.dto.req;
 import com.spacestar.back.alarm.domain.Alarm;
 import com.spacestar.back.alarm.enums.AlarmType;
 import com.spacestar.back.alarm.enums.CheckStatus;
+import com.spacestar.back.kafka.message.Message;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @Builder
 @Getter
@@ -18,13 +21,23 @@ public class AlarmAddReqDto {
 	private String content;
 	private AlarmType alarmType;
 
-	public static Alarm toEntity(String uuid, AlarmAddReqDto alarmAddReqDto){
-		return  Alarm.builder()
-				.receiverUuid(uuid)
-				.senderUuid(alarmAddReqDto.getSenderUuid())
-				.content(alarmAddReqDto.getContent())
-				.alarmType(alarmAddReqDto.getAlarmType())
-				.checkStatus(CheckStatus.UNREAD)
-				.build();
+	public static Alarm toEntity(String uuid, AlarmAddReqDto alarmAddReqDto) {
+		return Alarm.builder()
+			.receiverUuid(uuid)
+			.senderUuid(alarmAddReqDto.getSenderUuid())
+			.content(alarmAddReqDto.getContent())
+			.alarmType(alarmAddReqDto.getAlarmType())
+			.checkStatus(CheckStatus.UNREAD)
+			.build();
+	}
+
+	public static Alarm toEntitySSE(String uuid, Message message) {
+		return Alarm.builder()
+			.receiverUuid(message.getReceiverUuid())
+			.senderUuid(message.getSenderUuid())
+			.content(message.getContent())
+			.alarmType(message.getMessageType())
+			.checkStatus(CheckStatus.UNREAD)
+			.build();
 	}
 }

--- a/src/main/java/com/spacestar/back/alarm/service/AlarmService.java
+++ b/src/main/java/com/spacestar/back/alarm/service/AlarmService.java
@@ -4,9 +4,14 @@ import com.spacestar.back.alarm.dto.req.AlarmAddReqDto;
 import com.spacestar.back.alarm.dto.req.AlarmDeleteReqDto;
 import com.spacestar.back.alarm.dto.res.AlarmListResDto;
 import com.spacestar.back.alarm.dto.res.AlarmStateResDto;
+import com.spacestar.back.kafka.message.Message;
+
+import reactor.core.publisher.Flux;
 
 public interface AlarmService {
 
+	//실시간 알림 스트림 처리
+	Flux<Message> streamAlarms(String uuid);
 	//알림 추가
 	void addAlarm(String uuid, AlarmAddReqDto alarmAddReqDto);
 

--- a/src/main/java/com/spacestar/back/alarm/service/AlarmService.java
+++ b/src/main/java/com/spacestar/back/alarm/service/AlarmService.java
@@ -12,6 +12,7 @@ public interface AlarmService {
 
 	//실시간 알림 스트림 처리
 	Flux<Message> streamAlarms(String uuid);
+
 	//알림 추가
 	void addAlarm(String uuid, AlarmAddReqDto alarmAddReqDto);
 

--- a/src/main/java/com/spacestar/back/alarm/service/AlarmServiceImpl.java
+++ b/src/main/java/com/spacestar/back/alarm/service/AlarmServiceImpl.java
@@ -14,22 +14,34 @@ import com.spacestar.back.alarm.dto.res.AlarmStateResDto;
 import com.spacestar.back.alarm.repository.AlarmMongoRepository;
 import com.spacestar.back.global.GlobalException;
 import com.spacestar.back.global.ResponseStatus;
+import com.spacestar.back.kafka.message.FriendMessage;
+import com.spacestar.back.kafka.message.MatchingMessage;
+import com.spacestar.back.kafka.message.Message;
 
 import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
 
 @Service
 @RequiredArgsConstructor
 public class AlarmServiceImpl implements AlarmService {
 
 	private final AlarmMongoRepository alarmRepository;
+	private final Sinks.Many<MatchingMessage> matchingSink;
+	private final Sinks.Many<FriendMessage> friendSink;
 
-	// 알림 추가
+	@Override
+	public Flux<Message> streamAlarms(String uuid){
+		return Flux.merge(
+			matchingSink.asFlux(),
+			friendSink.asFlux()
+		).filter(message -> uuid.equals(message.getReceiverUuid()));
+	}
 	@Override
 	public void addAlarm(String uuid, AlarmAddReqDto alarmAddReqDto) {
 		alarmRepository.save(AlarmAddReqDto.toEntity(uuid, alarmAddReqDto));
 	}
 
-	// 알림 리스트 조회
 	@Override
 	public AlarmListResDto getAlarmList(String uuid) {
 
@@ -46,7 +58,6 @@ public class AlarmServiceImpl implements AlarmService {
 			.build();
 	}
 
-	// 알림 상태 조회
 	@Override
 	public AlarmStateResDto getAlarmState(String uuid, String id) {
 		Alarm alarm = alarmRepository.findByReceiverUuidAndId(uuid, id)
@@ -57,7 +68,6 @@ public class AlarmServiceImpl implements AlarmService {
 			.build();
 	}
 
-	// 알림 읽음 처리
 	@Override
 	public void modifyAlarmRead(String alarmId, String uuid){
 		// 변경사항이 없을 경우 : 알림이 존재하지 않거나 && 알림이 이미 읽은 상태인 경우
@@ -66,7 +76,6 @@ public class AlarmServiceImpl implements AlarmService {
 		}
 	}
 
-	// 알림 삭제
 	@Override
 	public void deleteAlarm(String uuid, AlarmDeleteReqDto alarmDeleteReqDto){
 

--- a/src/main/java/com/spacestar/back/config/KafkaConfig.java
+++ b/src/main/java/com/spacestar/back/config/KafkaConfig.java
@@ -33,6 +33,7 @@ public class KafkaConfig {
 		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
 		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
 		return props;
 	}
 
@@ -62,7 +63,7 @@ public class KafkaConfig {
 		return new DefaultKafkaConsumerFactory<>(
 				commonConsumerConfig(),
 				new StringDeserializer(),
-				new JsonDeserializer<>(FriendMessage.class)
+				new JsonDeserializer<>(FriendMessage.class, false)
 		);
 	}
 

--- a/src/main/java/com/spacestar/back/global/ResponseSuccess.java
+++ b/src/main/java/com/spacestar/back/global/ResponseSuccess.java
@@ -14,6 +14,7 @@ public enum ResponseSuccess {
     ALARM_STATE_SELECT_SUCCESS(202, "알림 상태 조회를 성공하였습니다."),
     ALARM_CHECK_STATE_UPDATE_SUCCESS(203, "알림 조회 상태 수정를 성공하였습니다."),
     ALARM_LIST_DELETE_SUCCESS(204, "알림 삭제를 성공하였습니다."),
+    ALARM_RECEIVED_SUCCESS(205, "알림이 성공적으로 수신되었습니다."),
 
 
 

--- a/src/main/java/com/spacestar/back/kafka/message/FriendMessage.java
+++ b/src/main/java/com/spacestar/back/kafka/message/FriendMessage.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class FriendMessage {
+public class FriendMessage implements Message{
 
 	private String senderUuid;
 	private String receiverUuid;

--- a/src/main/java/com/spacestar/back/kafka/message/FriendMessage.java
+++ b/src/main/java/com/spacestar/back/kafka/message/FriendMessage.java
@@ -1,5 +1,7 @@
 package com.spacestar.back.kafka.message;
 
+import com.spacestar.back.alarm.enums.AlarmType;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,4 +18,9 @@ public class FriendMessage implements Message{
 	private String senderUuid;
 	private String receiverUuid;
 	private String content;
+
+	@Override
+	public AlarmType getMessageType(){
+		return AlarmType.FRIEND;
+	}
 }

--- a/src/main/java/com/spacestar/back/kafka/message/MatchingMessage.java
+++ b/src/main/java/com/spacestar/back/kafka/message/MatchingMessage.java
@@ -1,5 +1,7 @@
 package com.spacestar.back.kafka.message;
 
+import com.spacestar.back.alarm.enums.AlarmType;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,4 +18,9 @@ public class MatchingMessage implements Message{
 	private String senderUuid;
 	private String receiverUuid;
 	private String content;
+
+	@Override
+	public AlarmType getMessageType(){
+		return AlarmType.MATCHING;
+	}
 }

--- a/src/main/java/com/spacestar/back/kafka/message/MatchingMessage.java
+++ b/src/main/java/com/spacestar/back/kafka/message/MatchingMessage.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class MatchingMessage {
+public class MatchingMessage implements Message{
 
 	private String senderUuid;
 	private String receiverUuid;

--- a/src/main/java/com/spacestar/back/kafka/message/Message.java
+++ b/src/main/java/com/spacestar/back/kafka/message/Message.java
@@ -1,0 +1,9 @@
+package com.spacestar.back.kafka.message;
+
+public interface Message {
+
+	String getSenderUuid();
+	String getReceiverUuid();
+	String getContent();
+
+}

--- a/src/main/java/com/spacestar/back/kafka/message/Message.java
+++ b/src/main/java/com/spacestar/back/kafka/message/Message.java
@@ -1,9 +1,12 @@
 package com.spacestar.back.kafka.message;
 
+import com.spacestar.back.alarm.enums.AlarmType;
+
 public interface Message {
 
 	String getSenderUuid();
 	String getReceiverUuid();
 	String getContent();
 
+	AlarmType getMessageType();
 }

--- a/src/main/java/com/spacestar/back/kafka/service/KafkaServiceImpl.java
+++ b/src/main/java/com/spacestar/back/kafka/service/KafkaServiceImpl.java
@@ -27,7 +27,7 @@ public class KafkaServiceImpl implements KafkaService {
 	}
 
 	@Override
-	@KafkaListener(topics = "dev.profile-service.friend-request", groupId = "friend_1",
+	@KafkaListener(topics = "dev.profile-service.friend-request", groupId = "friend_2",
 			containerFactory = "friendMessageKafkaListenerContainerFactory")
 	public void friendListen(FriendMessage message) {
 		log.info("수신 : {}", message);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #16 

## 📝작업 내용

> 알림이 성공적으로 전송되면, 알림 정보를 데이터베이스에 저장하는 작업을 비동기적으로 수행한다. 

1. **알림 스트림 병합** : 친구 알림과 매칭 알림의 스트림을 병합하여 처리한다.
2. **수신자 필터링** : 각 스트림에서 특정 수신자(uuid)에 해당하는 메시지만 전송한다.
3. **알림 저장** : 알림들을 데이터베이스에 저장된다. 이 작업은 비동기적으로 수행된다.

### 스크린샷 (선택)

- **알림 수신**
![image](https://github.com/Dreaming-Star/space-star-back-alarm/assets/102746730/6e1a50cc-babd-4598-89cf-b08dd0767b01)

- **데이터베이스 저장**
![image](https://github.com/Dreaming-Star/space-star-back-alarm/assets/102746730/55734053-7487-4402-a704-29b2a61204f4)

